### PR TITLE
Add navbar config example to theme.md

### DIFF
--- a/exampleSite/content/en/configuration/theme.md
+++ b/exampleSite/content/en/configuration/theme.md
@@ -86,7 +86,26 @@ menu:
 ---
 ```
 
+### Navbar settings in config
 If you try to put entry that aren't attached to a piece of content, or you want to organize your navbar into a single file, checkout [Add Non-content Entries to a Menu](https://gohugo.io/content-management/menus#add-non-content-entries-to-a-menu) and set these values in your toml settings file.
+
+```
+menu:
+  navbar:
+  - identifier: about
+    name: about
+    title: about
+    url: /about/
+    weight: 100
+  - identifier: series
+    name: series
+    url: /series/
+    weight: -100
+  - identifier: categories
+    name: categories
+    url: /categories/
+    weight: 80
+```
 
 ## External Library
 


### PR DESCRIPTION
Existing hugo docs use

Menu:
  Main:

where we want to change `main` to `navbar` for this theme