### PR TITLE
Add config.yaml and toml example of menu.navbar settings

### DIFF
--- a/exampleSite/content/en/configuration/theme.md
+++ b/exampleSite/content/en/configuration/theme.md
@@ -89,7 +89,28 @@ menu:
 ### Navbar settings in config
 If you try to put entry that aren't attached to a piece of content, or you want to organize your navbar into a single file, checkout [Add Non-content Entries to a Menu](https://gohugo.io/content-management/menus#add-non-content-entries-to-a-menu) and set these values in your toml settings file.
 
+```toml
+[[menu.navbar]]
+identifier = "about"
+name = "about"
+title = "about"
+url = "/about/"
+weight = 100
+
+[[menu.navbar]]
+identifier = "series"
+name = "series"
+url = "/series/"
+weight = -100
+
+[[menu.navbar]]
+identifier = "categories"
+name = "categories"
+url = "/categories/"
+weight = 80
 ```
+
+```yaml
 menu:
   navbar:
   - identifier: about


### PR DESCRIPTION
Existing hugo docs show menu settings as `[[menu.main]]`. This theme wants to use `[[menu.navbar]] instead.

updated docs with examples of config.yaml and config.toml settings for navbar because it took me a while to figure it out!

(I apologize for the messy pull requests. I'm new to this!) 